### PR TITLE
Naprawa tabelek

### DIFF
--- a/public/menu_main.css
+++ b/public/menu_main.css
@@ -350,7 +350,11 @@ th {
 
 #leaderboard {
   width: 100%;
-  display: flex;
+  height: 90%;
+  max-height: 600px;
+  overflow-y : auto;
+  overflow-x: auto;
+  display: block;
   justify-content: center;
   align-items: flex-start;
   padding: 0;
@@ -376,7 +380,14 @@ th {
   min-width: 100px;
 }
 
+#leaderboard thead {
+  display: table-header-group;
+}
+
 #leaderboard th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
   font-weight: bold;
   color: #fff;
   background: rgba(83, 25, 175, 0.7);


### PR DESCRIPTION
Propozycja naprawy błędu tabeli liderów. Problem polegał na tym, że tabela w pionie wykraczała poza granice bloku.